### PR TITLE
Include Winsock2.h instead of Windows.h in DebugTrace.h

### DIFF
--- a/Code/GraphMol/FMCS/DebugTrace.h
+++ b/Code/GraphMol/FMCS/DebugTrace.h
@@ -16,7 +16,7 @@
 #include <iostream>
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
-#include <Windows.h>  // for Winmm.lib timeGetTime()
+#include <Winsock2.h> // for timeval
 #ifdef _DEBUG         // check memory leaks
 #include <crtdbg.h>
 #define _CRTDBG_MAP_ALLOC


### PR DESCRIPTION
Including `Winsock2.h` has a number of advantages:
* It is much smaller than `Windows.h`, improving build time.
* It allows rdkit to be used in environments where `WIN32_LEAN_AND_MEAN` is set.
* It is [the recommended way to get `timeval`](https://docs.microsoft.com/en-us/windows/win32/api/winsock/ns-winsock-timeval) (rdkit doesn't actually use `timeGetTime`).

PR into rdkit: https://github.com/rdkit/rdkit/pull/3756