### PR TITLE
[POSSIBLY REDUNDANT] Cxx17 compatibility fixes for the Rosetta fork of RDKit.

### DIFF
--- a/Code/DataStructs/MultiFPBReader.cpp
+++ b/Code/DataStructs/MultiFPBReader.cpp
@@ -29,7 +29,7 @@ std::uint8_t *bitsetToBytes(const boost::dynamic_bitset<> &bitset);
 
 namespace {
 struct tplSorter
-    : public std::function<bool(MultiFPBReader::ResultTuple,
+    : public std::function<bool(MultiFPBReader::ResultTuple, /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
                                   MultiFPBReader::ResultTuple)> {
   bool operator()(const MultiFPBReader::ResultTuple &v1,
                   const MultiFPBReader::ResultTuple &v2) const {
@@ -45,7 +45,7 @@ struct tplSorter
   }
 };
 struct pairSorter
-    : public std::function<bool(std::pair<unsigned int, unsigned int>,
+    : public std::function<bool(std::pair<unsigned int, unsigned int>, /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
                                   std::pair<unsigned int, unsigned int>)> {
   bool operator()(const std::pair<unsigned int, unsigned int> &v1,
                   const std::pair<unsigned int, unsigned int> &v2) const {

--- a/Code/DataStructs/MultiFPBReader.cpp
+++ b/Code/DataStructs/MultiFPBReader.cpp
@@ -29,8 +29,8 @@ std::uint8_t *bitsetToBytes(const boost::dynamic_bitset<> &bitset);
 
 namespace {
 struct tplSorter
-    : public std::binary_function<MultiFPBReader::ResultTuple,
-                                  MultiFPBReader::ResultTuple, bool> {
+    : public std::function<bool(MultiFPBReader::ResultTuple,
+                                  MultiFPBReader::ResultTuple)> {
   bool operator()(const MultiFPBReader::ResultTuple &v1,
                   const MultiFPBReader::ResultTuple &v2) const {
     if (v1.get<0>() == v2.get<0>()) {
@@ -45,8 +45,8 @@ struct tplSorter
   }
 };
 struct pairSorter
-    : public std::binary_function<std::pair<unsigned int, unsigned int>,
-                                  std::pair<unsigned int, unsigned int>, bool> {
+    : public std::function<bool(std::pair<unsigned int, unsigned int>,
+                                  std::pair<unsigned int, unsigned int>)> {
   bool operator()(const std::pair<unsigned int, unsigned int> &v1,
                   const std::pair<unsigned int, unsigned int> &v2) const {
     if (v1.first == v2.first) {

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -81,7 +81,7 @@ bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
 }
 
 struct _possibleCompare
-    : public std::binary_function<PossibleType, PossibleType, bool> {
+    : public std::function<bool(PossibleType, PossibleType)> {
   bool operator()(const PossibleType &arg1, const PossibleType &arg2) const {
     return (arg1.get<0>() < arg2.get<0>());
   }

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -81,7 +81,7 @@ bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
 }
 
 struct _possibleCompare
-    : public std::function<bool(PossibleType, PossibleType)> {
+    : public std::function<bool(PossibleType, PossibleType)> { /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
   bool operator()(const PossibleType &arg1, const PossibleType &arg2) const {
     return (arg1.get<0>() < arg2.get<0>());
   }

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -335,7 +335,7 @@ void _setRingAngle(Atom::HybridizationType aHyb, unsigned int ringSize,
   }
 }
 
-struct lessVector : public std::binary_function<INT_VECT, INT_VECT, bool> {
+struct lessVector : public std::function<bool( INT_VECT, INT_VECT )> {
   bool operator()(const INT_VECT &v1, const INT_VECT &v2) const {
     return v1.size() < v2.size();
   }

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -335,7 +335,7 @@ void _setRingAngle(Atom::HybridizationType aHyb, unsigned int ringSize,
   }
 }
 
-struct lessVector : public std::function<bool( INT_VECT, INT_VECT )> {
+struct lessVector : public std::function<bool( INT_VECT, INT_VECT )> { /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
   bool operator()(const INT_VECT &v1, const INT_VECT &v2) const {
     return v1.size() < v2.size();
   }

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -203,7 +203,7 @@ void findSSSRforDupCands(const ROMol &mol, VECT_INT_VECT &res,
   }      // end of loop over all set of duplicate candidates
 }
 
-struct compRingSize : public std::function<bool(INT_VECT, INT_VECT)> {
+struct compRingSize : public std::function<bool(INT_VECT, INT_VECT)> { /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
   bool operator()(const INT_VECT &v1, const INT_VECT &v2) const {
     return v1.size() < v2.size();
   }

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -203,7 +203,7 @@ void findSSSRforDupCands(const ROMol &mol, VECT_INT_VECT &res,
   }      // end of loop over all set of duplicate candidates
 }
 
-struct compRingSize : public std::binary_function<INT_VECT, INT_VECT, bool> {
+struct compRingSize : public std::function<bool(INT_VECT, INT_VECT)> {
   bool operator()(const INT_VECT &v1, const INT_VECT &v2) const {
     return v1.size() < v2.size();
   }

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -28,7 +28,7 @@ namespace Rankers {
 // compared.
 template <typename T1, typename T2>
 struct pairGreater
-    : public std::function<bool( std::pair<T1, T2>, std::pair<T1, T2>) > {
+    : public std::function<bool( std::pair<T1, T2>, std::pair<T1, T2>) > { /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
   bool operator()(const std::pair<T1, T2> &v1,
                   const std::pair<T1, T2> &v2) const {
     return v1.first > v2.first;
@@ -39,7 +39,7 @@ struct pairGreater
 // compared.
 template <typename T1, typename T2>
 struct pairLess
-    : public std::function<bool( std::pair<T1, T2>, std::pair<T1, T2> ) > {
+    : public std::function<bool( std::pair<T1, T2>, std::pair<T1, T2> ) > { /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
   bool operator()(const std::pair<T1, T2> &v1,
                   const std::pair<T1, T2> &v2) const {
     return v1.first < v2.first;
@@ -47,9 +47,9 @@ struct pairLess
 };
 
 template <typename T>
-class argless : public std::function<bool( T, T ) > {
+class argless : public std::function<bool( T, T ) > { /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
  public:
-  argless(const T &c) : std::function<bool( T, T )>(), container(c){};
+  argless(const T &c) : std::function<bool( T, T )>(), container(c){}; /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
   bool operator()(unsigned int v1, unsigned int v2) const {
     return container[v1] < container[v2];
   }

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -28,7 +28,7 @@ namespace Rankers {
 // compared.
 template <typename T1, typename T2>
 struct pairGreater
-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool> {
+    : public std::function<bool( std::pair<T1, T2>, std::pair<T1, T2>) > {
   bool operator()(const std::pair<T1, T2> &v1,
                   const std::pair<T1, T2> &v2) const {
     return v1.first > v2.first;
@@ -39,7 +39,7 @@ struct pairGreater
 // compared.
 template <typename T1, typename T2>
 struct pairLess
-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool> {
+    : public std::function<bool( std::pair<T1, T2>, std::pair<T1, T2> ) > {
   bool operator()(const std::pair<T1, T2> &v1,
                   const std::pair<T1, T2> &v2) const {
     return v1.first < v2.first;
@@ -47,9 +47,9 @@ struct pairLess
 };
 
 template <typename T>
-class argless : public std::binary_function<T, T, bool> {
+class argless : public std::function<bool( T, T ) > {
  public:
-  argless(const T &c) : std::binary_function<T, T, bool>(), container(c){};
+  argless(const T &c) : std::function<bool( T, T )>(), container(c){};
   bool operator()(unsigned int v1, unsigned int v2) const {
     return container[v1] < container[v2];
   }

--- a/Code/RDGeneral/hash/extensions.hpp
+++ b/Code/RDGeneral/hash/extensions.hpp
@@ -66,7 +66,7 @@ namespace gboost
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
 
     template <class T> struct hash
-        : std::unary_function<T, std::hash_result_t>
+        : std::function<std::hash_result_t(T)>
     {
 #if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
         std::hash_result_t operator()(T const& val) const
@@ -83,7 +83,7 @@ namespace gboost
 
 #if BOOST_WORKAROUND(__DMC__, <= 0x848)
     template <class T, unsigned int n> struct hash<T[n]>
-        : std::unary_function<T[n], std::hash_result_t>
+        : std::function<std::hash_result_t(T[n])>
     {
         std::hash_result_t operator()(const T* val) const
         {
@@ -110,7 +110,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : std::unary_function<T, std::hash_result_t>
+                : std::function<std::hash_result_t(T)>
             {
 #if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
                 std::hash_result_t operator()(T const& val) const
@@ -136,7 +136,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : public std::unary_function<T, std::hash_result_t>
+                : public std::function<std::hash_result_t(T)>
             {
                 std::hash_result_t operator()(T const& val) const
                 {
@@ -155,7 +155,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : public std::unary_function<T, std::hash_result_t>
+                : public std::function<std::hash_result_t(T)>
             {
                 std::hash_result_t operator()(T& val) const
                 {

--- a/Code/RDGeneral/hash/extensions.hpp
+++ b/Code/RDGeneral/hash/extensions.hpp
@@ -66,7 +66,7 @@ namespace gboost
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
 
     template <class T> struct hash
-        : std::function<std::hash_result_t(T)>
+        : std::function<std::hash_result_t(T)> /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
     {
 #if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
         std::hash_result_t operator()(T const& val) const
@@ -83,7 +83,7 @@ namespace gboost
 
 #if BOOST_WORKAROUND(__DMC__, <= 0x848)
     template <class T, unsigned int n> struct hash<T[n]>
-        : std::function<std::hash_result_t(T[n])>
+        : std::function<std::hash_result_t(T[n])> /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
     {
         std::hash_result_t operator()(const T* val) const
         {
@@ -110,7 +110,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : std::function<std::hash_result_t(T)>
+                : std::function<std::hash_result_t(T)> /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
             {
 #if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
                 std::hash_result_t operator()(T const& val) const
@@ -136,7 +136,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : public std::function<std::hash_result_t(T)>
+                : public std::function<std::hash_result_t(T)> /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
             {
                 std::hash_result_t operator()(T const& val) const
                 {
@@ -155,7 +155,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : public std::function<std::hash_result_t(T)>
+                : public std::function<std::hash_result_t(T)> /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
             {
                 std::hash_result_t operator()(T& val) const
                 {

--- a/Code/RDGeneral/hash/hash.hpp
+++ b/Code/RDGeneral/hash/hash.hpp
@@ -372,6 +372,8 @@ namespace gboost
     //
 
 #if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
+
+/*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
 #define BOOST_HASH_SPECIALIZE(type) \
     template <> struct hash<type> \
          : public std::function<std::hash_result_t(type)> \
@@ -382,6 +384,7 @@ namespace gboost
         } \
     };
 
+/*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
 #define BOOST_HASH_SPECIALIZE_REF(type) \
     template <> struct hash<type> \
          : public std::function<std::hash_result_t(type)> \
@@ -392,6 +395,8 @@ namespace gboost
         } \
     };
 #else
+
+/*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
 #define BOOST_HASH_SPECIALIZE(type) \
     template <> struct hash<type> \
          : public std::function<std::hash_result_t(type)> \
@@ -411,6 +416,7 @@ namespace gboost
         } \
     };
 
+/*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
 #define BOOST_HASH_SPECIALIZE_REF(type) \
     template <> struct hash<type> \
          : public std::function<std::hash_result_t(type)> \
@@ -455,7 +461,7 @@ namespace gboost
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
     template <class T>
     struct hash<T*>
-        : public std::function<std::hash_result_t(T*)>
+        : public std::function<std::hash_result_t(T*)> /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
     {
         std::hash_result_t operator()(T* v) const
         {
@@ -480,7 +486,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : public std::function<std::hash_result_t(T)>
+                : public std::function<std::hash_result_t(T)> /*Modified for Rosetta CXX17 compatibility.  Resolve merge conflicts in favour of the primary RDKit repository.  VKM, 24 May 2024.*/
             {
                 std::hash_result_t operator()(T val) const
                 {

--- a/Code/RDGeneral/hash/hash.hpp
+++ b/Code/RDGeneral/hash/hash.hpp
@@ -374,7 +374,7 @@ namespace gboost
 #if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
 #define BOOST_HASH_SPECIALIZE(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
+         : public std::function<std::hash_result_t(type)> \
     { \
         std::hash_result_t operator()(type v) const \
         { \
@@ -384,7 +384,7 @@ namespace gboost
 
 #define BOOST_HASH_SPECIALIZE_REF(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
+         : public std::function<std::hash_result_t(type)> \
     { \
         std::hash_result_t operator()(type const& v) const \
         { \
@@ -394,7 +394,7 @@ namespace gboost
 #else
 #define BOOST_HASH_SPECIALIZE(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
+         : public std::function<std::hash_result_t(type)> \
     { \
         std::hash_result_t operator()(type v) const \
         { \
@@ -403,7 +403,7 @@ namespace gboost
     }; \
     \
     template <> struct hash<const type> \
-         : public std::unary_function<const type, std::hash_result_t> \
+         : public std::function<std::hash_result_t(const type)> \
     { \
         std::hash_result_t operator()(const type v) const \
         { \
@@ -413,7 +413,7 @@ namespace gboost
 
 #define BOOST_HASH_SPECIALIZE_REF(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
+         : public std::function<std::hash_result_t(type)> \
     { \
         std::hash_result_t operator()(type const& v) const \
         { \
@@ -422,7 +422,7 @@ namespace gboost
     }; \
     \
     template <> struct hash<const type> \
-         : public std::unary_function<const type, std::hash_result_t> \
+         : public std::function<std::hash_result_t(const type)> \
     { \
         std::hash_result_t operator()(type const& v) const \
         { \
@@ -455,7 +455,7 @@ namespace gboost
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
     template <class T>
     struct hash<T*>
-        : public std::unary_function<T*, std::hash_result_t>
+        : public std::function<std::hash_result_t(T*)>
     {
         std::hash_result_t operator()(T* v) const
         {
@@ -480,7 +480,7 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : public std::unary_function<T, std::hash_result_t>
+                : public std::function<std::hash_result_t(T)>
             {
                 std::hash_result_t operator()(T val) const
                 {


### PR DESCRIPTION
The Rosetta fork of RDKit currently fails to compile on Mac/clang with `extras=cxx17` (or `extras=masala`, which turns on Cxx17 compilation).  This PR removes some instances of the deprecated `std::unary_function` and `std::binary_function`, switching them to `std::function`.  Notes on this:

1.  This may not be the best way to make the switch.
2.  This may have already been fixed in a better way in the main RDKit repo, in which case we should just close this PR and update to their version.

@roccomoretti 

EDIT: A year and a half later, I forgot that I had done this, and did it again a slightly different way.  Please take your pick of pull request #4 or this one, and close the other.