### PR TITLE
Fix the C++17 build

### DIFF
--- a/Code/DataStructs/MultiFPBReader.cpp
+++ b/Code/DataStructs/MultiFPBReader.cpp
@@ -28,9 +28,7 @@ std::uint8_t *bitsetToBytes(const boost::dynamic_bitset<> &bitset);
 }
 
 namespace {
-struct tplSorter
-    : public std::binary_function<MultiFPBReader::ResultTuple,
-                                  MultiFPBReader::ResultTuple, bool> {
+struct tplSorter {
   bool operator()(const MultiFPBReader::ResultTuple &v1,
                   const MultiFPBReader::ResultTuple &v2) const {
     if (v1.get<0>() == v2.get<0>()) {
@@ -44,9 +42,7 @@ struct tplSorter
     }
   }
 };
-struct pairSorter
-    : public std::binary_function<std::pair<unsigned int, unsigned int>,
-                                  std::pair<unsigned int, unsigned int>, bool> {
+struct pairSorter {
   bool operator()(const std::pair<unsigned int, unsigned int> &v1,
                   const std::pair<unsigned int, unsigned int> &v2) const {
     if (v1.first == v2.first) {

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -80,8 +80,7 @@ bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
            !isUnsaturated(atom, mol)));
 }
 
-struct _possibleCompare
-    : public std::binary_function<PossibleType, PossibleType, bool> {
+struct _possibleCompare {
   bool operator()(const PossibleType &arg1, const PossibleType &arg2) const {
     return (arg1.get<0>() < arg2.get<0>());
   }

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -335,7 +335,7 @@ void _setRingAngle(Atom::HybridizationType aHyb, unsigned int ringSize,
   }
 }
 
-struct lessVector : public std::binary_function<INT_VECT, INT_VECT, bool> {
+struct lessVector {
   bool operator()(const INT_VECT &v1, const INT_VECT &v2) const {
     return v1.size() < v2.size();
   }

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -203,7 +203,7 @@ void findSSSRforDupCands(const ROMol &mol, VECT_INT_VECT &res,
   }      // end of loop over all set of duplicate candidates
 }
 
-struct compRingSize : public std::binary_function<INT_VECT, INT_VECT, bool> {
+struct compRingSize {
   bool operator()(const INT_VECT &v1, const INT_VECT &v2) const {
     return v1.size() < v2.size();
   }

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -27,8 +27,7 @@ namespace Rankers {
 //! functor for implementing > on two std::pairs.  The first entries are
 // compared.
 template <typename T1, typename T2>
-struct pairGreater
-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool> {
+struct pairGreater {
   bool operator()(const std::pair<T1, T2> &v1,
                   const std::pair<T1, T2> &v2) const {
     return v1.first > v2.first;
@@ -38,8 +37,7 @@ struct pairGreater
 //! function for implementing < on two std::pairs.  The first entries are
 // compared.
 template <typename T1, typename T2>
-struct pairLess
-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool> {
+struct pairLess {
   bool operator()(const std::pair<T1, T2> &v1,
                   const std::pair<T1, T2> &v2) const {
     return v1.first < v2.first;
@@ -47,9 +45,9 @@ struct pairLess
 };
 
 template <typename T>
-class argless : public std::binary_function<T, T, bool> {
+class argless {
  public:
-  argless(const T &c) : std::binary_function<T, T, bool>(), container(c){};
+  argless(const T &c) : container(c){};
   bool operator()(unsigned int v1, unsigned int v2) const {
     return container[v1] < container[v2];
   }

--- a/Code/RDGeneral/hash/extensions.hpp
+++ b/Code/RDGeneral/hash/extensions.hpp
@@ -66,7 +66,6 @@ namespace gboost
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
 
     template <class T> struct hash
-        : std::unary_function<T, std::hash_result_t>
     {
 #if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
         std::hash_result_t operator()(T const& val) const

--- a/Code/RDGeneral/hash/hash.hpp
+++ b/Code/RDGeneral/hash/hash.hpp
@@ -374,7 +374,6 @@ namespace gboost
 #if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
 #define BOOST_HASH_SPECIALIZE(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
     { \
         std::hash_result_t operator()(type v) const \
         { \
@@ -384,7 +383,6 @@ namespace gboost
 
 #define BOOST_HASH_SPECIALIZE_REF(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
     { \
         std::hash_result_t operator()(type const& v) const \
         { \
@@ -394,7 +392,6 @@ namespace gboost
 #else
 #define BOOST_HASH_SPECIALIZE(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
     { \
         std::hash_result_t operator()(type v) const \
         { \
@@ -403,7 +400,6 @@ namespace gboost
     }; \
     \
     template <> struct hash<const type> \
-         : public std::unary_function<const type, std::hash_result_t> \
     { \
         std::hash_result_t operator()(const type v) const \
         { \
@@ -413,7 +409,6 @@ namespace gboost
 
 #define BOOST_HASH_SPECIALIZE_REF(type) \
     template <> struct hash<type> \
-         : public std::unary_function<type, std::hash_result_t> \
     { \
         std::hash_result_t operator()(type const& v) const \
         { \
@@ -422,7 +417,6 @@ namespace gboost
     }; \
     \
     template <> struct hash<const type> \
-         : public std::unary_function<const type, std::hash_result_t> \
     { \
         std::hash_result_t operator()(type const& v) const \
         { \
@@ -455,7 +449,6 @@ namespace gboost
 #if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
     template <class T>
     struct hash<T*>
-        : public std::unary_function<T*, std::hash_result_t>
     {
         std::hash_result_t operator()(T* v) const
         {
@@ -480,7 +473,6 @@ namespace gboost
         {
             template <class T>
             struct inner
-                : public std::unary_function<T, std::hash_result_t>
             {
                 std::hash_result_t operator()(T val) const
                 {


### PR DESCRIPTION
Neither std::binary_function nor std::unary_function are needed in modern C++, particularly if your struct or class defines operator(). Both are removed in C++17 (which was preventing compilation with the C++17 standard).

EDIT: Drat.  I see I already did exactly this, in pull request #3.  OK, that one changes `std::binary_function` and `std::unary_function` to use `std::function` instead, while this one simply takes them out.  Either one is a valid fix.  Please choose one or the other, and close the other PR.